### PR TITLE
fix line diff as tslint/formatters/checkstyleFormatter

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -34,8 +34,8 @@ class Formatter {
     
     formatError(failure) {
         const start = failure.startPosition || DefaultPosition;
-        const line = start.lineAndCharacter.line;
-        const character = start.lineAndCharacter.character;
+        const line = start.lineAndCharacter.line + 1;
+        const character = start.lineAndCharacter.character + 1;
         const message = _.escape(failure.failure);
         const severity = this.settings.severity;
         

--- a/test/mocks/output.js
+++ b/test/mocks/output.js
@@ -13,8 +13,8 @@ const dirty = {
     fileName: 'dirty.ts',
     path: '/home/ubuntu/workspace/sandbox/data/dirty.ts',
     failures: [
-        '<error line="7" column="4" severity="error" message="default access modifier on member/method not allowed" source="member-access"/>',
-        '<error line="1" column="15" severity="error" message="expected member-variable-declaration: &#39;str&#39; to have a typedef" source="typedef"/>'
+        '<error line="8" column="5" severity="error" message="default access modifier on member/method not allowed" source="member-access"/>',
+        '<error line="2" column="16" severity="error" message="expected member-variable-declaration: &#39;str&#39; to have a typedef" source="typedef"/>'
     ]
 };
 
@@ -22,15 +22,15 @@ const awful = {
     fileName: 'awful.ts',
     path: '/home/ubuntu/workspace/sandbox/data/awful.ts',
     failures: [
-        '<error line="6" column="4" severity="error" message="default access modifier on member / method not allowed" source="member-access"/>',
-        '<error line="3" column="18" severity="error" message="block is empty" source="no-empty"/>',
-        '<error line="8" column="19" severity="error" message="object access via string literals is disallowed" source="no-string-literal"/>',
-        '<error line="5" column="0" severity="error" message="trailing whitespace" source="no-trailing-whitespace"/>',
-        '<error line="1" column="12" severity="error" message="unused variable: &#39;str&#39;" source="no-unused-variable"/>',
-        '<error line="7" column="8" severity="error" message="forbidden &#39;var&#39; keyword, use &#39;let&#39; or &#39;const&#39; instead" source="no-var-keyword"/>',
-        '<error line="7" column="20" severity="error" message="missing semicolon" source="semicolon"/>',
-        '<error line="1" column="15" severity="error" message="expected member - variable - declaration: &#39;str&#39; to have a typedef" source="typedef"/>',
-        '<error line="6" column="9" severity="error" message="expected call - signature: &#39;chop&#39; to have a typedef" source="typedef"/>'
+        '<error line="7" column="5" severity="error" message="default access modifier on member / method not allowed" source="member-access"/>',
+        '<error line="4" column="19" severity="error" message="block is empty" source="no-empty"/>',
+        '<error line="9" column="20" severity="error" message="object access via string literals is disallowed" source="no-string-literal"/>',
+        '<error line="6" column="1" severity="error" message="trailing whitespace" source="no-trailing-whitespace"/>',
+        '<error line="2" column="13" severity="error" message="unused variable: &#39;str&#39;" source="no-unused-variable"/>',
+        '<error line="8" column="9" severity="error" message="forbidden &#39;var&#39; keyword, use &#39;let&#39; or &#39;const&#39; instead" source="no-var-keyword"/>',
+        '<error line="8" column="21" severity="error" message="missing semicolon" source="semicolon"/>',
+        '<error line="2" column="16" severity="error" message="expected member - variable - declaration: &#39;str&#39; to have a typedef" source="typedef"/>',
+        '<error line="7" column="10" severity="error" message="expected call - signature: &#39;chop&#39; to have a typedef" source="typedef"/>'
     ]
 };
 


### PR DESCRIPTION
I fixed the issue of wrong output line / column.

startPosition of tslint information is start from 0.
but file start usually 1.

I fixed like as original [tslint/formatters/checkstyleFormatter](https://github.com/palantir/tslint/blob/eb047b7125d67ddde22c6ecbf103f9299ca9d806/src/formatters/checkstyleFormatter.ts#L58-L59) 